### PR TITLE
chore: strict typing and correct errors

### DIFF
--- a/contrib/mkbbsmenu.py
+++ b/contrib/mkbbsmenu.py
@@ -65,9 +65,6 @@ if __name__ == "__main__":
     # Avoid `BrokenPipeError` when running `... | head`
     signal(SIGPIPE, SIG_DFL)
 
-    # Avoid `UnicodeDecodeError`
-    if isinstance(sys.stdin, io.TextIOWrapper):
-        sys.stdin.reconfigure(encoding="shift-jis")
 
     parser = BBSMenuParser()
     parser.feed(sys.stdin.read())

--- a/contrib/mkbbsmenu.py
+++ b/contrib/mkbbsmenu.py
@@ -1,59 +1,81 @@
-import sys
+from __future__ import annotations
 
+import csv
+import sys
+import io
 from dataclasses import dataclass
 from enum import Enum
 from html.parser import HTMLParser
-from typing import Optional
+from signal import SIG_DFL, SIGPIPE, signal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import ClassVar
+
 
 class State(Enum):
     NONE = 1
     B = 2
     A = 3
 
+
 @dataclass
 class Board:
-    href: str
+    href: str | None
     name: str
+
 
 class BBSMenuParser(HTMLParser):
     current_category: str = ""
-    current_board: Optional[Board] = None
+    current_board: Board | None = None
     state: State = State.NONE
-    boards: list[tuple[str, Board]] = []
+    boards: ClassVar[list[tuple[str, Board | None]]] = []
 
-    def handle_starttag(self, tag, attrs):
-        #print(f"starttag: {tag}, current state: {self.state}")
-        if tag == "b": #and self.state == State.SECOND_BR:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # print(f"starttag: {tag}, current state: {self.state}")
+        if tag == "b":  # and self.state == State.SECOND_BR:
             self.state = State.B
         elif tag == "a":
             self.state = State.A
             href = list(filter(lambda x: x[0] == "href", attrs))
-            self.current_board = Board(href = href[0][1], name = "")
-        #print(f"starttag: {tag}, changed state: {self.state}")
+            self.current_board = Board(href=href[0][1], name="")
+        # print(f"starttag: {tag}, changed state: {self.state}")
 
-    def handle_data(self, data):
-        #print(f"data, current: {self.state}, {self.current_category}, {self.current_board}")
+    def handle_data(self, data: str) -> None:
+        # print(f"data, current: {self.state}, {self.current_category}, {self.current_board}")
         if self.state == State.B:
             self.current_category = data
-            #print(f"changed cat: {self.current_category}, current: {self.state}")
+            # print(f"changed cat: {self.current_category}, current: {self.state}")
         elif self.state == State.A:
-            self.current_board.name = data
-            #print(f"board: {self.current_board}, current: {self.state}, {self.current_category}")
+            if self.current_board is not None:
+                self.current_board.name = data
+            # print(f"board: {self.current_board}, current: {self.state}, {self.current_category}")
 
-    def handle_endtag(self, tag):
+    def handle_endtag(self, tag: str) -> None:
         if self.state == State.A:
-            self.boards.append((self.current_category, self.current_board))
+            if self.boards is not None:
+                self.boards.append((self.current_category, self.current_board))
             self.current_board = None
 
         self.state = State.NONE
-        #print(f"endtag: {tag}, current: {self.state}, {self.current_category}")
+        # print(f"endtag: {tag}, current: {self.state}, {self.current_category}")
 
 
-parser = BBSMenuParser()
-parser.feed(sys.stdin.read())
+if __name__ == "__main__":
+    # Avoid `BrokenPipeError` when running `... | head`
+    signal(SIGPIPE, SIG_DFL)
 
-#print(parser.boards)
+    # Avoid `UnicodeDecodeError`
+    if isinstance(sys.stdin, io.TextIOWrapper):
+        sys.stdin.reconfigure(encoding="shift-jis")
 
-for i in parser.boards:
-    if i[0] is None or i[0] == "": continue
-    print(f"\"{i[1].href}\",{i[0]},{i[1].name}")
+    parser = BBSMenuParser()
+    parser.feed(sys.stdin.read())
+
+    # print(parser.boards)
+
+    writer = csv.writer(sys.stdout, quoting=csv.QUOTE_ALL)
+    for category, board in parser.boards:
+        if not category or not board:
+            continue
+        writer.writerow((board.href, category, board.name))

--- a/contrib/mkbbsmenu.py
+++ b/contrib/mkbbsmenu.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import csv
 import sys
-import io
 from dataclasses import dataclass
 from enum import Enum
 from html.parser import HTMLParser


### PR DESCRIPTION
`contrib/mkbbsmenu.py` について、いくつか改善を入れています。でか変更が1コミットになってるんですが、必要なのは以下の変更のうち上2つだと思うのでPRを閉じてそれだけ直してもらってもいいです。

---

<s>

`curl menu.5ch.net/bbsmenu.html | nkf | python contrib/mkbbsmenu.py` とやらないと `UnicodeDecodeError` で怒られていたので sjisでエンコーディングするようにしました。

</s>

`... | head` のように出力にパイプをつなげた時 `BrokenPipeError` で怒られていたので `signal(SIGPIPE, SIG_DFL)` をしました。

結果の出力時`csv.writer.writerow`で適切にquoteを入れるようにしました。

`mypy --strict` でエラーが出ないようにしました。

